### PR TITLE
use consistent naming schema for the network interfaces attached to auxiliary networks

### DIFF
--- a/controller/cni/cni.go
+++ b/controller/cni/cni.go
@@ -25,10 +25,11 @@ import (
 	"strings"
 	"sync"
 
+	kc "github.com/kaloom/kubernetes-common"
+
 	"github.com/containernetworking/cni/libcni"
 	cnitypes "github.com/containernetworking/cni/pkg/types"
 	"github.com/golang/glog"
-	"k8s.io/kubernetes/pkg/kubelet/dockershim/network"
 	utilexec "k8s.io/utils/exec"
 )
 
@@ -240,7 +241,7 @@ func (plugin *NetworkPlugin) buildCNIRuntimeConf(cniParams *Parameters) (*libcni
 	rt := &libcni.RuntimeConf{
 		ContainerID: cniParams.SandboxID,
 		NetNS:       cniParams.NetnsPath,
-		IfName:      network.DefaultInterfaceName,
+		IfName:      kc.GetNetworkIfname(cniParams.NetworkName),
 		Args: [][2]string{
 			{"IgnoreUnknown", "1"},
 			{"K8S_POD_NAMESPACE", cniParams.Namespace},

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -49,7 +49,7 @@ func (ct ContainerType) String() string {
 	case Crio:
 		return "Crio"
 	default:
-		glog.Errorf("Invalid ContainerType: %v", ct)
+		glog.Errorf("Invalid ContainerType: %d", int(ct))
 		return fmt.Sprintf("%d", int(ct))
 	}
 }

--- a/controller/crio-runtime/runtime.go
+++ b/controller/crio-runtime/runtime.go
@@ -86,15 +86,15 @@ func (cr *CrioRuntime) GetNetNS(podSandboxID string) (string, error) {
 	glog.V(5).Infof("GetNetNS:info:%s", info)
 	err = json.Unmarshal([]byte(info), &podStatusResponseInfo)
 	if err != nil {
-		glog.Errorf("GetNetNS:error decoding response:", err)
+		glog.Errorf("GetNetNS:error decoding response: %v", err)
 		if e, ok := err.(*json.SyntaxError); ok {
-			glog.Errorf("GetNetNS:syntax error at byte offset ", e.Offset)
+			glog.Errorf("GetNetNS:syntax error at byte offset %d", e.Offset)
 		}
 		return "", err
 	}
 
 	namespaces := podStatusResponseInfo.RunTimeSpec.Linux.NameSpaces
-	glog.V(5).Infof("GetNetNS:RunTimeSpec.Linux.NameSpaces:", namespaces)
+	glog.V(5).Infof("GetNetNS:RunTimeSpec.Linux.NameSpaces: %v", namespaces)
 	for _, namespace := range namespaces {
 		if namespace.Type == "network" {
 			ss := strings.Split(namespace.Path, "/")


### PR DESCRIPTION
This is needed to avoid having libcni would collude the cni result  cache under /var/lib/cni/results of the dynamic network interfaces
 with one associated with eth0
