### PR TITLE
Remove usage of deprecated API removed in Kubernetes 1.22

### DIFF
--- a/manifests/podagent-serviceaccount-and-rbac.yaml
+++ b/manifests/podagent-serviceaccount-and-rbac.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
 ---
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: podagent
 rules:
@@ -25,7 +25,7 @@ rules:
       - get
 ---
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: podagent
 roleRef:


### PR DESCRIPTION
* rbac.authorization.k8s.io/v1beta1