### PR TITLE
Fix podagent

### DIFF
--- a/controller/pods.go
+++ b/controller/pods.go
@@ -305,13 +305,14 @@ func (c *Controller) watchPods(ctx context.Context, nodeName string) (cache.Cont
 	fieldsToMatch := fs.AsSelector()
 	// Define what we want to look for (Pods)
 	watchlist := cache.NewListWatchFromClient(c.kubeClient.CoreV1().RESTClient(), "pods", apiv1.NamespaceAll, fieldsToMatch)
-	// batching and collapsing events is controlled by the resyncPeriod, 0 would disable the resync
-	resyncPeriod := 30 * time.Second
 	// Setup an informer to call functions when the watchlist changes
 	_, controller := cache.NewInformer(
 		watchlist,
 		&apiv1.Pod{},
-		resyncPeriod,
+		// we don't use any resync because UpdateFunc logic currently compares
+		// the annotations between the old and new objects, but during a resync,
+		// old == new so nothing happens
+		0,
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: c.podAdded,
 			UpdateFunc: c.podUpdated,


### PR DESCRIPTION
    Fix inconsistent state when podagent is down
    
    This fixes some cases (but not all) where there can be an inconsistent
    state between what the annotations describes and what CNI configuration
    have actually been run.
    
    eg: When a node reboot and Pod foo is started, then annotated BEFORE
    podagent has started.
    
    Note that with this change, the CNI configuration MUST be idempotent
    because they will be re-run whenever podagent restarts.